### PR TITLE
Makefile corrected. JSctags lives.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ install:
 	$(INSTALL) -d $(PREFIX)/narcissus/lib
 	$(INSTALL) $(LIB_NARCISSUS_SRC) $(PREFIX)/narcissus/lib
 	echo "export NODE_PATH=$(PREFIX)/lib/jsctags/:\$$NODE_PATH" >> $(PROFILE)
+	@echo "\nIf you want to use jsctags right here, right now,\n\
+	please type this in your terminal:\n\n\
+	    . $(PROFILE)\n"
 
 uninstall:
 	rm -rf $(BIN_SRC:%.js=$(PREFIX)/%) $(PREFIX)/lib/jsctags \


### PR DESCRIPTION
I wanted to fiddle with jsctags the other day, and I realized I could not install it straight away. The Makefile was too old, and David Herman [told me](https://twitter.com/#!/littlecalculist/status/101690772138635264) on Twitter that nobody really cared enough to fix it.

I cared.

---

This commit only impacts on the Makefile, which means it does not have side-effects on the rest of the project.

---

Please review it. There may be a more straightforward manner.
- Added `LIB_CFA2_SRC` since the position of cfa has moved away from `narcissus/`;
- Modified `LIB_NARCISSUS_SRC` since narcissus itself has moved away from `lib/`;
- Corrected `make uninstall` as well.
