### PR TITLE
Fixed #21: `make install` prints a message explaining users can add jstags to NODE_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ install:
 	@echo "\nIf you want to use jsctags right here, right now,\n\
 	please type this in your terminal:\n\n\
 	    . $(PROFILE)\n"
+	@echo "\nIf you want jsctags to work anywhere in the terminal,\n\
+	add this to your ~/.bashrc (Linux) or ~/.bash_profile (OSX):\n\n\
+        NODE_PATH='$(PREFIX)/lib/jsctags:\$${NODE_PATH}'\n"
 
 uninstall:
 	rm -rf $(BIN_SRC:%.js=$(PREFIX)/%) $(PREFIX)/lib/jsctags \


### PR DESCRIPTION
Fixes #21: Added a message explaining how to make jsctags work from anywhere in the terminal (by adding it to NODE_PATH).
