### PR TITLE
bug fixes, #16 and handling of exports_objects.lines

### DIFF
--- a/lib/cfa2/jscfa.js
+++ b/lib/cfa2/jscfa.js
@@ -1135,7 +1135,7 @@ function tagVarRefsId(classifyEvents) {
       n.kind = HEAP;
       n.addr = exports_object_av_addr;
       var p = arguments[3]; // exported property name passed as extra arg
-      if (p.type === STRING)
+      if (p && p.type === STRING)
         exports_object.lines[p.value.slice(0, -1)] = p.lineno;
       return;
     }
@@ -3651,7 +3651,7 @@ function getTags(ast, pathtofile, lines, options) {
       return (ch in REGEX_ESCAPES) ? REGEX_ESCAPES[ch] : "\\" + ch;
     }
     str || (str = "");
-    return "/^" + str.replace(/[\\/$\n\r\t]/g, subst) + "$/";
+    return "/^" + str.replace(/[\\/$\n\r\t]/g, subst).replace(/\\r$/,'') + "$/";
   }
 
   if (options.commonJS) commonJSmode = true;
@@ -3664,9 +3664,9 @@ function getTags(ast, pathtofile, lines, options) {
     eo.forEachOwnProp(function (p) {
       var av = eo.getOwnExactProp(p);
       var tag = {};
-      tag.name = /-$/.test(p) ? p.slice(0, -1) : p.slice(1);
+      tag.name = /-$/.test(p) ? p.slice(0, -1) : p.slice(1); // cr: ?slice(1)?
       tag.tagfile = pathtofile;
-      tag.addr = regexify(lines[exports_object.lines[p] - 1]);
+      tag.addr = regexify(lines[exports_object.lines[tag.name] - 1]);
       var type = av.toType();
       if (/(^<.*> function)|(^[^<>\|]*function)/.test(type))
         tag.kind = "f";
@@ -3674,7 +3674,7 @@ function getTags(ast, pathtofile, lines, options) {
         tag.kind = "v";
       tag.type = type;
       tag.module = options.module;
-      tag.lineno = exports_object.lines[p];
+      tag.lineno = exports_object.lines[tag.name].toString();
       tags.push(tag);
     });
   }


### PR DESCRIPTION
- #16: on windows, with CRLF fileendings, tag addresses end with
     \r, causing tag lookup to fail
     remove those '\r$' in regexify
  TODO: line ending variations should be handled properly when
        splitting the file into lines in the first place
- for some reason, tagVarRefsId may be called on IDENTIFIER nodes
  without fourth argument (why?), for instance when processing
  lib/jsctags/traits.js;
  guard handling of exports_objects.lines to keep jsctags from
  falling over
  TODO: check whether this hides a bug
- in getTags, exports_objects.lines needs to be addressed with
  tag name, without trailing '-', to avoid undefined lineno
