### PR TITLE
This fixes issue #27 and makes doctorjs work with the Tagbar vim plugin again

### DIFF
--- a/bin/jsctags.js
+++ b/bin/jsctags.js
@@ -270,4 +270,6 @@ if (opts.hasOwnProperty('jsonp')) {
     tags.write(out, opts);
 }
 
-out.end();
+if (out != process.stdout) {
+    out.end();
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/doctorjs/issues/27
