### PR TITLE
Fix getting lineno of an exported object

### DIFF
--- a/lib/cfa2/jscfa.js
+++ b/lib/cfa2/jscfa.js
@@ -1165,8 +1165,9 @@ function tagVarRefsId(classifyEvents) {
       n.kind = HEAP;
       n.addr = exports_object_av_addr;
       var p = arguments[3]; // exported property name passed as extra arg
-      if (p.type === STRING)
-        exports_object.lines[p.value.slice(0, -1)] = p.lineno;
+      if (p.type === STRING) {
+        exports_object.lines[p.value.slice(0, -1)] = p.lineno.toString();
+      }
       return;
     }
     //print("global: " + varname + " :: " + n.lineno);
@@ -3772,7 +3773,10 @@ function getTags(ast, pathtofile, lines, options) {
         tag.kind = "v";
       tag.type = type;
       tag.module = options.module;
-      tag.lineno = exports_object.lines[p];
+
+      // in exports_object.lines the name has been changed
+      // see tagVarRefsId around line 1169
+      tag.lineno = exports_object.lines[p.slice(0, -1)];
       tags.push(tag);
     });
   }


### PR DESCRIPTION
The key of the exports_objects.lines is changed (the trailing - has been
removed). The trailing char should also be removed when we want to access to
it.
Also the lineno should be converted to string because a replace() gonna be
called on it
