### PR TITLE
jsctags works with nodejs 0.10.x again.

### DIFF
--- a/lib/jsctags/ctags/index.js
+++ b/lib/jsctags/ctags/index.js
@@ -43,11 +43,11 @@ var TagWriter = require('./writer').TagWriter;
 var Trait = require('../traits').Trait;
 
 exports.Tags = function (initialTags) {
-    this.tags = initialTags != null ? initialTags : [];
     this.init();
 };
 
 exports.Tags.prototype = Object.create(Object.prototype, Trait.compose(Trait({
+    tags: [],
     _search: function (id, pred) {
         var shadowTag = { name: id };
         var tags = this.tags;


### PR DESCRIPTION
The issue https://github.com/mozilla/doctorjs/issues/52 by @doovoochild has been closed, but the fix described by @chilkari in the discussion hasn’t been patched into master. Here is this patch.
