### PR TITLE
Mentions calling `git submodule` in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Building
 --------
 To install:
 
+* `git submodule update --init --recursive`
 * `make install`
 
 To uninstall:


### PR DESCRIPTION
In the README section that describes how to get things up and running there is no mention of the fact that `git submodule` needs to be called.

Although this may be obvious after closer examination of the code-base I think it would be better to mention this explicitly in the docs.
